### PR TITLE
Sets up JavaFX

### DIFF
--- a/src/edu/psu/teamone/main/Controller.java
+++ b/src/edu/psu/teamone/main/Controller.java
@@ -8,12 +8,11 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
-import javafx.scene.layout.StackPane;
+import javafx.scene.control.TabPane;
 
 public class Controller implements Initializable {
-
 	@FXML
-	private StackPane sceneStack;
+	private TabPane tabPane;
 
 	@Override
 	public void initialize(URL location, ResourceBundle resources) {

--- a/src/edu/psu/teamone/main/Controller.java
+++ b/src/edu/psu/teamone/main/Controller.java
@@ -1,0 +1,37 @@
+package edu.psu.teamone.main;
+
+import java.net.URL;
+import java.util.ResourceBundle;
+import javafx.application.Platform;
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.fxml.Initializable;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Alert.AlertType;
+import javafx.scene.layout.StackPane;
+
+public class Controller implements Initializable {
+
+	@FXML
+	private StackPane sceneStack;
+
+	@Override
+	public void initialize(URL location, ResourceBundle resources) {
+
+	}
+
+	@FXML
+	protected final void handleExitAction(ActionEvent event) {
+		Platform.exit();
+	}
+
+	@FXML
+	protected final void handleAboutAction(ActionEvent event) {
+		final Alert alert = new Alert(AlertType.INFORMATION);
+		alert.setTitle("About Schedule Application");
+		alert.setHeaderText("Copyright © 2016");
+		alert.setContentText("By CMPSC 221 Team One");
+
+		alert.showAndWait();
+	}
+}

--- a/src/edu/psu/teamone/main/ScheduleApplication.java
+++ b/src/edu/psu/teamone/main/ScheduleApplication.java
@@ -20,7 +20,7 @@ public class ScheduleApplication extends Application {
 		final Parent root = FXMLLoader.load(getClass().getResource("main.fxml"),
 				ResourceBundle.getBundle("edu.psu.teamone.main.messages"));
 
-		primaryStage.setTitle("Urika");
+		primaryStage.setTitle("Schedule Application");
 		primaryStage.setScene(new Scene(root));
 		primaryStage.show();
 	}

--- a/src/edu/psu/teamone/main/ScheduleApplication.java
+++ b/src/edu/psu/teamone/main/ScheduleApplication.java
@@ -1,13 +1,27 @@
 package edu.psu.teamone.main;
 
-import javax.swing.JFrame;
+import java.io.IOException;
+import java.util.ResourceBundle;
 
-public class ScheduleApplication {
-	private static JFrame mainFrame;
+import javafx.application.Application;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+public class ScheduleApplication extends Application {
 
 	public static void main(String[] args) {
-		mainFrame = new JFrame();
-		mainFrame.setVisible(true);
-		mainFrame.setSize(800, 600); // Change this in the future.
+		launch(args);
+	}
+
+	@Override
+	public final void start(Stage primaryStage) throws IOException {
+		final Parent root = FXMLLoader.load(getClass().getResource("main.fxml"),
+				ResourceBundle.getBundle("edu.psu.teamone.main.messages"));
+
+		primaryStage.setTitle("Urika");
+		primaryStage.setScene(new Scene(root));
+		primaryStage.show();
 	}
 }

--- a/src/edu/psu/teamone/main/main.fxml
+++ b/src/edu/psu/teamone/main/main.fxml
@@ -51,7 +51,7 @@
 	</VBox>
 	</top>
 	<center>
-		<TabPane>
+		<TabPane fx:id="tabPane">
 			<Tab text="Classes">
 
 			</Tab>

--- a/src/edu/psu/teamone/main/main.fxml
+++ b/src/edu/psu/teamone/main/main.fxml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.net.*?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
+<?import javafx.scene.image.*?>
+<?import javafx.scene.paint.Color?>
+
+<BorderPane fx:controller="edu.psu.teamone.main.Controller" xmlns:fx="http://javafx.com/fxml">
+	<top>
+	<VBox id="vbox">
+		<MenuBar fx:id="menuBar">
+			<menus>
+				<Menu text="%fileButton">
+					<items>
+						<MenuItem text="%newButton" accelerator="%newButton.accelerator"/>
+						<MenuItem fx:id="openButton" text="%openButton"
+							accelerator="%openButton.accelerator"/>
+						<MenuItem text="%saveButton" accelerator="%saveButton.accelerator"/>
+						<MenuItem text="%saveAsButton" accelerator="%saveAsButton.accelerator"/>
+						<SeparatorMenuItem/>
+						<MenuItem text="%exitButton" onAction="#handleExitAction"/>
+					</items>
+				</Menu>
+				<Menu text="%editButton">
+					<items>
+						<MenuItem text="%cutButton" accelerator="%cutButton.accelerator"/>
+						<MenuItem text="%copyButton" accelerator="%copyButton.accelerator"/>
+						<MenuItem text="%pasteButton" accelerator="%pasteButton.accelerator"/>
+					</items>
+				</Menu>
+				<Menu text="%helpButton">
+					<items>
+						<MenuItem text="%documentationButton" accelerator="F1"/>
+						<MenuItem text="%websiteButton"/>
+						<SeparatorMenuItem/>
+						<MenuItem text="%aboutButton" onAction="#handleAboutAction"/>
+					</items>
+				</Menu>
+			</menus>
+		</MenuBar>
+		<ToolBar>
+			<Button fx:id="newButton">
+				<tooltip>
+					<Tooltip text="%newButton"/>
+				</tooltip>
+			</Button>
+		</ToolBar>
+	</VBox>
+	</top>
+	<center>
+		<TabPane>
+			<Tab text="Classes">
+
+			</Tab>
+			<Tab text="Instructors">
+
+			</Tab>
+			<Tab text="Schedules">
+
+			</Tab>
+		</TabPane>
+	</center>
+	<bottom>
+		<FlowPane id="statusBar" fx:id="statusBar">
+		</FlowPane>
+	</bottom>
+</BorderPane>

--- a/src/edu/psu/teamone/main/messages.properties
+++ b/src/edu/psu/teamone/main/messages.properties
@@ -1,0 +1,24 @@
+fileButton=File
+newButton=New
+newButton.accelerator=Shortcut+N
+loadButton=Load
+openButton=Open
+openButton.accelerator=Shortcut+O
+saveButton=Save
+saveButton.accelerator=Shortcut+S
+saveAsButton=Save As
+saveAsButton.accelerator=Shortcut+A
+exitButton=Exit
+
+editButton=Edit
+cutButton=Cut
+cutButton.accelerator=Shortcut+X
+copyButton=Copy
+copyButton.accelerator=Shortcut+C
+pasteButton=Paste
+pasteButton.accelerator=Shortcut+V
+
+helpButton=Help
+documentationButton=Documentation
+websiteButton=Website
+aboutButton=About


### PR DESCRIPTION
Alright I've replaced all of the Swing code with JavaFX.

We have messages.properties which is our resource bundle. The same technique is used in Swing, put all user facing text in this file. I also like to put keyboard shortcuts in here. Then when you need to change the text on Cut, Copy, or some other action you do it in one location instead of 50. This also makes it possible to translate the program into other languages and dialects (i18n or internationalization), but we're not concerned with that.

As you can see the layout file is a lot like HTML where you have onAction that handles a button being pressed. The difference is that it calls a method in Controller.java instead. However, it is actually possible to put JavaScript in here if you want to for simple actions. So it's basically a lot like making a web page. The Controller is named such because it serves the functionality of a controller in the Model-View-Controller design pattern.

This is what we have so far:
![Schedule Application JavaFX](https://cloud.githubusercontent.com/assets/3212801/15958107/8dbe197c-2ec1-11e6-815a-121241394a5c.png)

The FXML file can be opened and changed in scene builder or you can modify it by hand. We can also add custom CSS later if we need to style the application for any reason, but I don't think we will need to.